### PR TITLE
updating resolvers

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ val appName = "health-indicators"
 val silencerVersion = "1.7.1"
 
 lazy val microservice = Project(appName, file("."))
-  .enablePlugins(play.sbt.PlayScala, SbtAutoBuildPlugin, SbtGitVersioning, SbtDistributablesPlugin)
+  .enablePlugins(play.sbt.PlayScala, SbtDistributablesPlugin)
   .disablePlugins(JUnitXmlReportPlugin) //Required to prevent https://github.com/scalatest/scalatest/issues/1427
   .settings(
     majorVersion                     := 0,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,7 @@ resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts
 
 resolvers += Resolver.typesafeRepo("releases")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.0.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.3.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "2.1.0")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,8 +5,6 @@ resolvers += Resolver.typesafeRepo("releases")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.3.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "2.1.0")
-
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.0.0")
 
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.7")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,10 +1,7 @@
-resolvers += Resolver.url("HMRC Sbt Plugin Releases", url("https://dl.bintray.com/hmrc/sbt-plugin-releases"))(
-  Resolver.ivyStylePatterns)
-
-resolvers += "HMRC Releases" at "https://dl.bintray.com/hmrc/releases"
+resolvers += MavenRepository("HMRC-open-artefacts-maven2", "https://open.artefacts.tax.service.gov.uk/maven2")
+resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(Resolver.ivyStylePatterns)
 
 resolvers += Resolver.typesafeRepo("releases")
-
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.11.0")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,7 @@ resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts
 
 resolvers += Resolver.typesafeRepo("releases")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.11.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.0.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "2.1.0")
 


### PR DESCRIPTION
# Changes

Following the advice [here](https://confluence.tools.tax.service.gov.uk/pages/viewpage.action?pageId=256476338):

- update resolvers
  https://github.com/hmrc/health-indicators/blob/441895ebae1a6ef3a298f0ca563d3a95cd0a4a6e/project/plugins.sbt#L1-L2
- update sbt-auto-build plugin
  https://github.com/hmrc/health-indicators/blob/1d501cb85b1b757c22f1c18bc9aff55ae985ec8e/project/plugins.sbt#L6
- no more explicit dependency on `sbt-auto-build` and `git-versioning`
  https://github.com/hmrc/health-indicators/blob/1d501cb85b1b757c22f1c18bc9aff55ae985ec8e/build.sbt#L11